### PR TITLE
Show latest commit hash on main page

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,10 @@ from openai import OpenAI
 import openai
 from pydantic import BaseModel
 import humanize
+import git
+
+repo = git.Repo(search_parent_directories=True)
+sha = repo.head.object.hexsha[:7]
 
 # check if .env file exists
 if not os.path.exists(".env"):
@@ -175,7 +179,7 @@ our_tools = [
 
 @app.route("/")
 def index():
-    return render_template("index.html", tools=our_tools)
+    return render_template("index.html", tools=our_tools, hash=sha)
 
 
 @app.route("/hex2rgb")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openai
 flask
 pydantic
 humanize
+gitpython

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
 			<div class="title-container">
 				<h1 class="title">Tools</h1>
 				<h2 class="subtitle">Some of our favourites:</h2>
+				<p>Latest hash: {{ hash }}</p>
 			</div>
 			<div class="grid is-col-min-6">
 				{% for tool in tools %}


### PR DESCRIPTION
Add to main file, add new requirement, and update index.html

## Summary by Sourcery

Display the latest commit hash on the main page by integrating GitPython to retrieve the hash and updating the index template to show it.

New Features:
- Display the latest commit hash on the main page by retrieving it using the GitPython library.

Enhancements:
- Update the main application to pass the latest commit hash to the index template.

Build:
- Add GitPython as a new dependency in the requirements.txt file.