### PR TITLE
Allow for pasting images, and changing the number of colors in a palette

### DIFF
--- a/templates/im2palette.html
+++ b/templates/im2palette.html
@@ -14,6 +14,13 @@
 			src="https://st.editid.uk/script.js"
 			data-website-id="fd60c701-ca5b-4ddc-9a0d-5602adf865d5"
 		></script>
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+			integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"
+		/>
 	</head>
 	<body>
 		{# adds the nav bar to the file #} {% include 'nav.html' %}
@@ -26,6 +33,7 @@
 					<img src="" alt="Image" id="im" />
 				</div>
 				<div id="palette">
+					<button id="reset" class="button is-danger">Reset</button>
 					<p class="has-text-centered mb-3">Palette:</p>
 					<div id="palettecolors" class="columns"></div>
 				</div>
@@ -42,12 +50,32 @@
 					</div>
 				</div>
 				<div id="upload">
-					<p class="has-text-centered">Upload:</p>
-					<input
-						type="file"
-						id="imageinput"
-						accept="image/jpeg, image/png, image/gif, image/webp, image/bmp"
-					/>
+					<label for="palette" class="label">Colors in palette:</label>
+					<div class="select mb-2">
+						<select class="" id="palettecount">
+							<option id="2">2</option>
+							<option id="3">3</option>
+							<option id="4">4</option>
+							<option id="5" selected>5</option>
+						</select>
+					</div>
+					<p class="has-text-centered label">Upload:</p>
+					<div class="file">
+						<label class="file-label">
+							<input
+								type="file"
+								id="imageinput"
+								accept="image/jpeg, image/png, image/gif, image/webp, image/bmp"
+								class="file-input"
+							/>
+							<span class="file-cta">
+								<span class="file-icon">
+									<i class="fas fa-upload"></i>
+								</span>
+								<span class="file-label">Choose a file...</span>
+							</span>
+						</label>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -72,6 +100,8 @@
 		var confirm_im = document.getElementById("confirm");
 		var upload = document.getElementById("upload");
 		var image_input = document.getElementById("imageinput");
+		var palettecount = document.getElementById("palettecount");
+		var stage = 0;
 		image_input.addEventListener("change", function () {
 			// if there's a file in the input, hide the upload div, show the preview div
 			if (image_input.files.length > 0) {
@@ -79,6 +109,7 @@
 				preview.style.display = "block";
 				// set the image source of #confirm
 				confirm_im.src = URL.createObjectURL(image_input.files[0]);
+				stage = 1;
 			}
 		});
 		// if the cancel button is clicked, hide the preview div, show the upload div, reset the image source of #confirm, and reset the image source of #imageinput
@@ -87,6 +118,7 @@
 			upload.style.display = "block";
 			confirm_im.src = "";
 			image_input.value = "";
+			stage = 0;
 		});
 		// if the create button is clicked, hide the preview div, show the #image div, and set the image source of #im
 		create_button.addEventListener("click", function () {
@@ -95,7 +127,7 @@
 			palettediv.style.display = "block";
 			im.src = confirm_im.src;
 			palette_colors.innerHTML = "";
-			var palette = colorThief.getPalette(confirm_im, 5);
+			var palette = colorThief.getPalette(confirm_im, parseInt(palettecount.value));
 			for (var i = 0; i < palette.length; i++) {
 				var color = palette[i];
 				var div = document.createElement("div");
@@ -103,6 +135,7 @@
 				div.style.backgroundColor = "rgb(" + color.join(",") + ")";
 				palette_colors.appendChild(div);
 			}
+			stage = 2;
 		});
 		document.addEventListener("click", function (e) {
 			if (e.target.classList.contains("palette-color")) {
@@ -145,6 +178,44 @@
 				// remove event listener from delete button
 			}, 5000);
 		}
+		document.getElementById("reset").addEventListener("click", function () {
+			confirm_im.src = "";
+			image_input.value = "";
+			preview.style.display = "none";
+			upload.style.display = "block";
+			image.style.display = "none";
+			palettediv.style.display = "none";
+			stage = 0;
+		});
+		function handlePasteToFileInput(fileInput) {
+			document.addEventListener("paste", (event) => {
+				const clipboardItems = event.clipboardData.items;
+				for (const item of clipboardItems) {
+					if (item.type.startsWith("image/")) {
+						const file = item.getAsFile();
+						if (file) {
+							// Create a DataTransfer object to set the file input
+							const dataTransfer = new DataTransfer();
+							dataTransfer.items.add(file);
+							fileInput.files = dataTransfer.files;
+							console.log(
+								"Image pasted and set to file input:",
+								file
+							);
+							// trigger change event
+							fileInput.dispatchEvent(new Event("change"));
+						}
+						break;
+					} else {
+						console.log(
+							"Clipboard item is not an image:",
+							item.type
+						);
+					}
+				}
+			});
+		}
+		handlePasteToFileInput(image_input);
 	</script>
 	<style>
 		#image {
@@ -187,6 +258,11 @@
 			display: flex;
 			flex-direction: column;
 			gap: 1rem;
+		}
+		.file {
+			display: flex;
+			justify-content: center;
+			align-items: center;
 		}
 	</style>
 </html>


### PR DESCRIPTION
- Add support for pasting images
- Add support for changing number of colors in a palette

Addresses issue #31

## Summary by Sourcery

Implement image pasting and palette color count adjustment features, enhancing user interaction with the application.

New Features:
- Add support for pasting images directly into the application.
- Introduce functionality to change the number of colors in a palette through a dropdown menu.

Enhancements:
- Add a reset button to clear the current image and palette selections.