### PR TITLE
Create a socketio tester

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,6 +177,11 @@ our_tools = [
         "name": "Password Generator",
         "url": "/password_generator",
         "description": "Generate a password.",
+    },
+    {
+        "name": "Socket.IO Tester",
+        "url": "/socketio",
+        "description": "Test Socket.IO connections.",
     }
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 humanize
 gitpython
 sentry-sdk[flask]
+flask-socketio

--- a/socketioserv.py
+++ b/socketioserv.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template, request
+from flask_socketio import SocketIO
+import os
+from dotenv import load_dotenv
+load_dotenv()
+from markupsafe import Markup
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', os.urandom(24))
+socketio = SocketIO(app)
+
+@app.route('/')
+def index():
+    return render_template('socketio.html')
+
+@app.context_processor
+def utility_processor():
+    to_return = {}
+    to_return["bulma"] = Markup('<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">')
+    to_return["fontawesome"] = Markup('<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />')
+    to_return['analytics'] = Markup('<script defer src="https://st.editid.uk/script.js" data-website-id="fd60c701-ca5b-4ddc-9a0d-5602adf865d5"></script>') if os.getenv("IS_PRODUCTION") else ''
+    return to_return
+    
+@socketio.on('message')
+def handle_message(message):
+    print('received message: ' + message)
+    # sanitize message
+    message = message.replace('<', '&lt;').replace('>', '&gt;')
+    # respond with message only to specific client
+    socketio.send(message, to=request.sid)
+
+if __name__ == '__main__':
+    socketio.run(app, host='0.0.0.0', port=5739, debug=True)

--- a/templates/redirto_socketio.html
+++ b/templates/redirto_socketio.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirecting...</title>
+    {{bulma}}
+</head>
+<body>
+    {% include 'nav.html' %}
+    <div class="container">
+        <div class="box mt-2 has-text-centered">
+            <h1 class="title">
+                You are about to be redirected.
+            </h1>
+            <p class="subtitle">
+                You are being redirected to our Socket.IO server.
+                Make sure you have JavaScript enabled.
+                Make sure the domain ends with <code>.modutools.com</code>.
+            </p>
+            <p>Redirecting in <code id="countdown">5</code></p>
+        </div>
+    </div>
+</body>
+<script>
+    let count = 5;
+    const timer = setInterval(() => {
+        count--;
+        document.getElementById("countdown").textContent = count;
+        if (count == 0) {
+            clearInterval(timer);
+            window.location.href = "https://socketio.modutools.com";
+        }
+    }, 1000);
+</script>
+</html>

--- a/templates/socketio.html
+++ b/templates/socketio.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Socket.IO Tester</title>
+		{{bulma}} {{analytics}}
+		<script src="https://cdn.jsdelivr.net/npm/socket.io-client@4.8.0/dist/socket.io.min.js"></script>
+	</head>
+	<body>
+		<div class="container">
+			<div class="box mt-2 has-text-centered">
+				<h1 class="title">Socket.IO Tester</h1>
+                <h2 class="subtitle">If you are connected with polling, then websockets are being blocked.</h2>
+				<div class="field has-addons has-addons-centered">
+					<p class="control">
+						<input
+							class="input"
+							type="text"
+							id="message"
+							placeholder="Enter message"
+						/>
+					</p>
+					<p class="control">
+						<a class="button is-info" onclick="sendMessage()"
+							>Send</a
+						>
+					</p>
+				</div>
+                <p>Currently connected with: <span id="curcon">Nothing</span></p>
+				<div id="messages"></div>
+			</div>
+		</div>
+	</body>
+	<script>
+		const socket = io();
+        var startTime = 0;
+        function updateConnections() {
+            const curcon = document.getElementById("curcon");
+            curcon.innerText = socket.io.engine.transport.name;
+        }
+		function sendMessage() {
+			const message = document.getElementById("message").value;
+			startTime = performance.now();
+			socket.emit("message", message);
+			document.getElementById("message").value = "";
+            updateConnections();
+		}
+		socket.on("message", (message) => {
+			const responseTime = performance.now() - startTime;
+			document.getElementById(
+				"messages"
+			).innerHTML += `<p>Server responded in ${responseTime.toFixed(
+				2
+			)}ms: <code>${message}</code></p>`;
+		});
+        socket.on("connect", updateConnections);
+        document.addEventListener("keydown", (e) => {
+            if (e.key === "Enter") {
+                sendMessage();
+            }
+        })
+	</script>
+</html>

--- a/tools.py
+++ b/tools.py
@@ -93,3 +93,7 @@ def uuid_generator():
 @tools_blueprint.route('/password_generator')
 def password_generator():
     return render_template('passwordgen.html')
+
+@tools_blueprint.route("/socketio")
+def socketio():
+    return render_template("redirto_socketio.html")


### PR DESCRIPTION
Create socketio tester

## Summary by Sourcery

Add a new Socket.IO tester feature to the application, including a web interface for testing connections and a redirect page to guide users to the Socket.IO server. Update the application routes to include the new tester functionality.

New Features:
- Introduce a Socket.IO tester feature that allows users to test Socket.IO connections through a new web interface.

Enhancements:
- Add a new route '/socketio' to the application for accessing the Socket.IO tester.

Documentation:
- Create a new HTML template 'socketio.html' for the Socket.IO tester interface, providing a user-friendly way to test connections.
- Add a redirect page 'redirto_socketio.html' to guide users to the Socket.IO server with a countdown and instructions.