### PR TITLE
Remove default opt-out capturing for PostHog in utility processor

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,6 @@ def utility_processor():
                 api_host: 'https://eu.i.posthog.com',
                 person_profiles: 'always', // or 'always' to create profiles for anonymous users as well
                 persistence: 'cookie',
-                opt_out_capturing_by_default: true
             })
             </script>
             '''.replace('[POSTHOG]', POSTHOG)

--- a/templates/cookies.html
+++ b/templates/cookies.html
@@ -75,7 +75,6 @@
     })
     document.getElementById('deny_cookies').addEventListener('click', function() {
         try {
-            posthog.opt_out_capturing()
             document.getElementById('cookiebanner').style.display = 'none';
             localStorage.setItem('cookies_enabled', '2')
             posthog.set_config({ persistence: 'memory' });


### PR DESCRIPTION
Eliminate the default setting that opts users out of capturing in the PostHog utility processor. This change simplifies the user experience regarding cookie consent.

## Summary by Sourcery

Remove the default opt-out capturing behavior in the PostHog utility processor and cookie consent mechanism.

New Features:
- Enable PostHog capturing by default, requiring users to explicitly opt out if desired.

Enhancements:
- Simplify the user experience regarding cookie consent by removing the default opt-out for PostHog capturing.